### PR TITLE
[fix] API 통신 연결 중 발생한 에러 수정 (카카오 로그인 & 회원 프로필 설정)

### DIFF
--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -8,6 +8,7 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 })
 
 apiClient.interceptors.request.use(config => {

--- a/src/api/apiClient.ts
+++ b/src/api/apiClient.ts
@@ -19,7 +19,8 @@ apiClient.interceptors.request.use(config => {
 apiClient.interceptors.response.use(
   response => response,
   error => {
-    window.location.href = '/login'
+    console.log('API 통신 에러:', error)
+    // window.location.href = '/login'
     return Promise.reject(error)
   }
 )

--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -1,16 +1,25 @@
-import apiClient from '@/api/apiClient'
+import axios from 'axios'
 
 interface LoginData {
   accessToken: string
   isNewUser: boolean
 }
 
+// no interceptors
 export const kakaoLogin = async (authCode: string) => {
   try {
-    const response = await apiClient.post<ApiResponse<LoginData>>(
-      '/auth/oauth/kakao',
+    const API_URL = import.meta.env.VITE_API_URL || ''
+
+    const response = await axios.post<ApiResponse<LoginData>>(
+      `${API_URL}/auth/oauth/kakao`,
       {
         code: authCode,
+      },
+      {
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        withCredentials: true,
       }
     )
     return response.data.data

--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -1,16 +1,19 @@
 import apiClient from '@/api/apiClient'
 
-interface LoginResponse {
+interface LoginData {
   accessToken: string
   isNewUser: boolean
 }
 
 export const kakaoLogin = async (authCode: string) => {
   try {
-    const response = await apiClient.post<LoginResponse>('/auth/oauth/kakao', {
-      code: authCode,
-    })
-    return response.data
+    const response = await apiClient.post<ApiResponse<LoginData>>(
+      '/auth/oauth/kakao',
+      {
+        code: authCode,
+      }
+    )
+    return response.data.data
   } catch (error) {
     console.error('카카오 로그인 에러:', error)
     throw error

--- a/src/api/authAPI.ts
+++ b/src/api/authAPI.ts
@@ -2,7 +2,6 @@ import apiClient from '@/api/apiClient'
 
 interface LoginResponse {
   accessToken: string
-  refreshToken: string
   isNewUser: boolean
 }
 

--- a/src/api/profileAPI.ts
+++ b/src/api/profileAPI.ts
@@ -1,10 +1,5 @@
 import apiClient from '@/api/apiClient'
 
-interface ApiResponse<T> {
-  message: string
-  data: T | null
-}
-
 export const submitUserProfile = async (profileData: UserProfile) => {
   try {
     const response = await apiClient.put<ApiResponse<null>>(
@@ -13,6 +8,7 @@ export const submitUserProfile = async (profileData: UserProfile) => {
     )
     return response.data
   } catch (error) {
-    console.log(error)
+    console.error('프로필 전송 에러:', error)
+    throw error
   }
 }

--- a/src/components/common/_ui/ClickableTag/ClickableTag.tsx
+++ b/src/components/common/_ui/ClickableTag/ClickableTag.tsx
@@ -1,3 +1,4 @@
+import { Check, Plus } from 'lucide-react'
 import styles from './styles.module.scss'
 
 interface ClickableTagProps {
@@ -19,6 +20,6 @@ export const ClickableTag: React.FC<ClickableTagProps> = ({
     className={`${styles.tag} ${selected ? styles.selected : ''} ${disabled ? styles.disabled : ''}`}
   >
     <span>{label}</span>
-    <span className={styles.icon}>{selected ? '✓' : '+'}</span>
+    <span className={styles.icon}>{selected ? <Check /> : <Plus />}</span>
   </button>
 )

--- a/src/components/common/_ui/ClickableTag/styles.module.scss
+++ b/src/components/common/_ui/ClickableTag/styles.module.scss
@@ -4,7 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 8px 16px;
+  padding: 6px 14px;
   border-radius: 9999px;
   background-color: #fff;
   opacity: 0.9;
@@ -18,6 +18,10 @@
     background-color: #02467d;
     color: #fff;
     opacity: 1;
+
+    .icon svg {
+      color: #fff;
+    }
   }
 
   &.disabled {
@@ -26,7 +30,12 @@
   }
 
   .icon {
-    margin-left: 8px;
+    margin-left: 3px;
     font-weight: bold;
+
+    svg {
+      color: #444;
+      width: 15px;
+    }
   }
 }

--- a/src/components/profile/SliderButtons/SliderButtons.tsx
+++ b/src/components/profile/SliderButtons/SliderButtons.tsx
@@ -2,7 +2,7 @@ import styles from './styles.module.scss'
 import { useSwiper } from 'swiper/react'
 import { useState, useEffect } from 'react'
 import { useProfileStore } from '@/stores/profileStore'
-import { submitUserProfile } from '@/api/\bprofileAPI'
+import { submitUserProfile } from '@/api/profileAPI'
 
 export const SliderButtons: React.FC = () => {
   const swiper = useSwiper()

--- a/src/components/profile/_steps/JobInterestStep/JobInterestStep.tsx
+++ b/src/components/profile/_steps/JobInterestStep/JobInterestStep.tsx
@@ -9,15 +9,15 @@ export const JobInterestStep: React.FC = () => {
   const [selected, setSelected] = useState<string[]>([])
 
   const taglist: string[] = [
-    '프론트엔드',
-    '솔루션즈 아키텍트',
-    '백엔드',
-    '클라우드 엔지니어',
-    '풀스택',
-    'AI 개발자',
-    'DevOps',
-    '머신러닝 엔지니어',
+    '백엔드 개발자',
+    '프론트엔드 개발자',
+    '풀스택 개발자',
     '데이터 사이언티스트',
+    '솔루션즈 아키텍트',
+    '클라우드 엔지니어',
+    '머신러닝 엔지니어',
+    'AI 백엔드 개발자',
+    'DevOps 엔지니어',
   ]
 
   const toggleTag = (tag: string): void => {

--- a/src/components/profile/_steps/TechStackStep/TechStackStep.tsx
+++ b/src/components/profile/_steps/TechStackStep/TechStackStep.tsx
@@ -9,28 +9,16 @@ export const TechStackStep: React.FC = () => {
   const [selected, setSelected] = useState<string[]>([])
 
   const taglist: string[] = [
-    'JavaScript',
-    'TypeScript',
-    'React',
-    'Vue',
-    'Angular',
-    'Node.js',
-    'Python',
+    'Typescript',
+    'Javascript',
     'Java',
     'Spring',
-    'C#',
-    'Go',
+    'React',
+    'Python',
     'AWS',
-    'Azure',
-    'GCP',
-    'Docker',
+    'Pytorch',
     'Kubernetes',
-    'TensorFlow',
-    'PyTorch',
-    'NoSQL',
-    'SQL',
     'Fastapi',
-    'GraphQL',
     'Langchain',
   ]
 

--- a/src/pages/auth/LoginRedirectPage/LoginRedirectPage.tsx
+++ b/src/pages/auth/LoginRedirectPage/LoginRedirectPage.tsx
@@ -1,5 +1,5 @@
 import { useNavigate, useLocation } from 'react-router-dom'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import { useAuthStore } from '@/stores/authStore'
 // import { kakaoLogin } from '@/api/authAPI'
 
@@ -11,9 +11,13 @@ export const LoginRedirectPage: React.FC = () => {
   const location = useLocation()
   const setTokens = useAuthStore(state => state.setTokens)
   const setIsNewUser = useAuthStore(state => state.setIsNewUser)
+  const isProcessing = useRef(false)
 
   useEffect(() => {
     const handleKakaoLogin = async () => {
+      if (isProcessing.current) return // API 중복 호출 방지
+      isProcessing.current = true
+
       try {
         const authCode = new URLSearchParams(location.search).get('code')
 
@@ -24,10 +28,9 @@ export const LoginRedirectPage: React.FC = () => {
         // const { accessToken, refreshToken, isNewUser } = await kakaoLogin(authCode)
 
         const accessToken = 'temp-accessToken-dfioasdvnkcvl'
-        const refreshToken = 'temp-refreshToken=qei912qu903'
         const isNewUser = true
 
-        setTokens(accessToken, refreshToken)
+        setTokens(accessToken)
         setIsNewUser(isNewUser)
 
         setInterval(() => {

--- a/src/pages/auth/LoginRedirectPage/LoginRedirectPage.tsx
+++ b/src/pages/auth/LoginRedirectPage/LoginRedirectPage.tsx
@@ -1,7 +1,7 @@
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useEffect, useRef } from 'react'
 import { useAuthStore } from '@/stores/authStore'
-// import { kakaoLogin } from '@/api/authAPI'
+import { kakaoLogin } from '@/api/authAPI'
 
 import styles from './styles.module.scss'
 import { LoadingIndicator } from '@/components/common'
@@ -21,19 +21,21 @@ export const LoginRedirectPage: React.FC = () => {
       try {
         const authCode = new URLSearchParams(location.search).get('code')
 
+        console.log(authCode)
+
         if (!authCode) {
           throw new Error('인가 코드를 찾을 수 없습니다.')
         }
 
-        // const { accessToken, refreshToken, isNewUser } = await kakaoLogin(authCode)
+        const { accessToken, isNewUser } = await kakaoLogin(authCode)
 
-        const accessToken = 'temp-accessToken-dfioasdvnkcvl'
-        const isNewUser = true
+        // const accessToken = 'temp-accessToken-dfioasdvnkcvl'
+        // const isNewUser = true
 
         setTokens(accessToken)
         setIsNewUser(isNewUser)
 
-        setInterval(() => {
+        setTimeout(() => {
           if (isNewUser) {
             navigate('/profile-setup', { replace: true })
           } else {

--- a/src/pages/auth/ProfileSetupPage/ProfileSetupPage.tsx
+++ b/src/pages/auth/ProfileSetupPage/ProfileSetupPage.tsx
@@ -1,7 +1,22 @@
 import { ProfileSlider } from '@/components/profile'
 import styles from './styles.module.scss'
+import { useEffect } from 'react'
 
 export const ProfileSetupPage: React.FC = () => {
+  useEffect(() => {
+    const handleTabKey = (e: KeyboardEvent) => {
+      if (e.key === 'Tab') {
+        e.preventDefault()
+      }
+    }
+
+    document.addEventListener('keydown', handleTabKey)
+
+    return () => {
+      document.removeEventListener('keydown', handleTabKey)
+    }
+  }, [])
+
   return (
     <div className={styles.pageContainer}>
       <h2 className={styles.guideText}>

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -6,7 +6,7 @@ interface AuthState {
   refreshToken: string | null
   isNewUser: boolean
 
-  setTokens: (accessToken: string, refreshToken: string) => void
+  setTokens: (accessToken: string) => void
   setIsNewUser: (isNewUser: boolean) => void
   isLoggedIn: () => boolean
 }
@@ -19,10 +19,9 @@ export const useAuthStore = create<AuthState>()(
       isNewUser: false,
 
       setIsNewUser: (isNewUser: boolean) => set({ isNewUser }),
-      setTokens: (accessToken: string, refreshToken: string) =>
+      setTokens: (accessToken: string) =>
         set({
           accessToken,
-          refreshToken,
         }),
 
       isLoggedIn: () => {

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -13,3 +13,8 @@ interface UserProfile {
   profileImageUrl: string | null
   seatPosition: [number, number]
 }
+
+interface ApiResponse<T = null> {
+  message: string
+  data: T
+}


### PR DESCRIPTION
## Description

백엔드와 API 통신 연결을 하며 발생했던 이슈들을 수정했습니다. 

## Changes Made

### 문제 1
- 원인 : CORS 에러. 
- 해결 : `withCredentials: true` 옵션 추가해서 해결
```tsx 
const apiClient = axios.create({
  baseURL: API_URL,
  headers: {
    'Content-Type': 'application/json',
  },
  withCredentials: true, // withCredentials 옵션 추가!
})
```

### 문제 2
- 원인 : 로그인 시, API 중복 요청으로 accessToken이 2개가 발급되는 문제
- 해결 : React Strict Mode 환경에서는 컴포넌트가 두 번 마운트되게 설정이 되있다. 그래서 API 요청 시에도 2번 호출이 되어 accessToken도 2개씩 발급되고 있었다. `useRef`로 이미 요청이 진행 중인지 확인하는 로직 추가해서 재요청이 가지않도록 설정했다 
> Tanstack Query를 쓰면 중복 요청 자동 처리가 가능하다. 추후 Tanstack Query로 리팩토링하기!
```tsx
  const isProcessing = useRef(false)

  useEffect(() => {
    const handleKakaoLogin = async () => {
      if (isProcessing.current) return // API 중복 호출 방지
      isProcessing.current = true
  
      try { //...
   }
```

### 문제 3
- 원인 : 로그인 요청 시 유효하지 않은 token 에러 발생
- 해결 : header에 토큰을 넣어 api 요청을 보내는 `interceptors` 방식이 로그인에도 적용되고 있었다. 그래서 로그인은 별도의 요청 로직을 만들어 적용했다. 로그인 제외 나머지는 그대로 사용.

### 문제 4
- 원인 : 응답 데이터 타입이 맞지않아 에러 발생
- 해결 : `data`가 한번 래핑되서 depth가 생기는 부분을 생각하지 못하고 타입을 설정해서 타입 오류가 발생했다. API Response 타입을 먼저 설정하고 그 안에 있는 data 타입을 후처리하는 방식으로 수정했다
```tsx 
interface ApiResponse<T = null> {
  message: string
  data: T
}

interface LoginData {
  accessToken: string
  isNewUser: boolean
}

const response = await axios.post<ApiResponse<LoginData>>() => {}
```

## Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.

