### PR TITLE
[style] 네비게이션 메뉴바 및 준비중 페이지 UI 추가

### DIFF
--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,47 +1,55 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { Home, Zap, BookCheck, MessageSquare, User } from 'lucide-react'
 import styles from './styles.module.scss'
 
 export const Navbar: React.FC = () => {
   const [activeTab, setActiveTab] = useState('home')
+  const navigate = useNavigate()
+  const location = useLocation()
 
-  const handleTabClick = (tab: string) => {
+  useEffect(() => {
+    if (location.pathname === '/') setActiveTab('home')
+  }, [location.pathname])
+
+  const handleTabClick = (tab: string, path: string) => {
     setActiveTab(tab)
+    navigate(path)
   }
 
   return (
     <div className={styles.navbar}>
       <div
         className={`${styles.navItem} ${activeTab === 'home' ? styles.active : ''}`}
-        onClick={() => handleTabClick('home')}
+        onClick={() => handleTabClick('home', '/')}
       >
         <Home />
         <span>매칭 홈</span>
       </div>
       <div
         className={`${styles.navItem} ${activeTab === 'interview' ? styles.active : ''}`}
-        onClick={() => handleTabClick('interview')}
+        onClick={() => handleTabClick('interview', '/coming-soon')}
       >
         <Zap />
         <span>면접실</span>
       </div>
       <div
         className={`${styles.navItem} ${activeTab === 'quiz' ? styles.active : ''}`}
-        onClick={() => handleTabClick('quiz')}
+        onClick={() => handleTabClick('quiz', '/coming-soon')}
       >
         <BookCheck />
         <span>오늘의 퀴즈</span>
       </div>
       <div
         className={`${styles.navItem} ${activeTab === 'chat' ? styles.active : ''}`}
-        onClick={() => handleTabClick('chat')}
+        onClick={() => handleTabClick('chat', '/coming-soon')}
       >
         <MessageSquare />
         <span>채팅</span>
       </div>
       <div
         className={`${styles.navItem} ${activeTab === 'mypage' ? styles.active : ''}`}
-        onClick={() => handleTabClick('mypage')}
+        onClick={() => handleTabClick('mypage', '/coming-soon')}
       >
         <User />
         <span>내 정보</span>

--- a/src/components/common/Navbar/Navbar.tsx
+++ b/src/components/common/Navbar/Navbar.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react'
+import { Home, Zap, BookCheck, MessageSquare, User } from 'lucide-react'
+import styles from './styles.module.scss'
+
+export const Navbar: React.FC = () => {
+  const [activeTab, setActiveTab] = useState('home')
+
+  const handleTabClick = (tab: string) => {
+    setActiveTab(tab)
+  }
+
+  return (
+    <div className={styles.navbar}>
+      <div
+        className={`${styles.navItem} ${activeTab === 'home' ? styles.active : ''}`}
+        onClick={() => handleTabClick('home')}
+      >
+        <Home />
+        <span>매칭 홈</span>
+      </div>
+      <div
+        className={`${styles.navItem} ${activeTab === 'interview' ? styles.active : ''}`}
+        onClick={() => handleTabClick('interview')}
+      >
+        <Zap />
+        <span>면접실</span>
+      </div>
+      <div
+        className={`${styles.navItem} ${activeTab === 'quiz' ? styles.active : ''}`}
+        onClick={() => handleTabClick('quiz')}
+      >
+        <BookCheck />
+        <span>오늘의 퀴즈</span>
+      </div>
+      <div
+        className={`${styles.navItem} ${activeTab === 'chat' ? styles.active : ''}`}
+        onClick={() => handleTabClick('chat')}
+      >
+        <MessageSquare />
+        <span>채팅</span>
+      </div>
+      <div
+        className={`${styles.navItem} ${activeTab === 'mypage' ? styles.active : ''}`}
+        onClick={() => handleTabClick('mypage')}
+      >
+        <User />
+        <span>내 정보</span>
+      </div>
+    </div>
+  )
+}

--- a/src/components/common/Navbar/styles.module.scss
+++ b/src/components/common/Navbar/styles.module.scss
@@ -1,0 +1,42 @@
+@import '@/styles/variables';
+
+.navbar {
+  width: 390px;
+  height: #{$nav-height};
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  box-shadow: 0 -2px 6px rgba(0, 0, 0, 0.03);
+  background-color: #fff;
+  z-index: 100;
+}
+
+.navItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  width: 20%;
+  height: 100%;
+  cursor: pointer;
+  color: #999;
+  transition: color 0.2s ease;
+
+  svg {
+    width: 22px;
+    height: 22px;
+  }
+
+  span {
+    font-size: 12px;
+    margin-top: 4px;
+  }
+
+  &:hover {
+    color: #444;
+  }
+}
+
+.active {
+  color: #000;
+}

--- a/src/components/common/_layout/Page/Page.tsx
+++ b/src/components/common/_layout/Page/Page.tsx
@@ -1,0 +1,20 @@
+import { Outlet } from 'react-router-dom'
+import { Navbar } from '@/components/common'
+import styles from './styles.module.scss'
+
+interface PageProps {
+  hasNavbar?: boolean
+}
+
+export const Page: React.FC<PageProps> = ({ hasNavbar = false }) => {
+  return (
+    <>
+      <div
+        className={`${styles.pageContainer} ${hasNavbar ? styles.hasNavbar : ''}`}
+      >
+        <Outlet />
+      </div>
+      {hasNavbar && <Navbar />}
+    </>
+  )
+}

--- a/src/components/common/_layout/Page/styles.module.scss
+++ b/src/components/common/_layout/Page/styles.module.scss
@@ -1,0 +1,12 @@
+@import '@/styles/variables';
+
+.pageContainer {
+  width: 100%;
+  height: 100vh;
+  padding: 0 15px;
+  overflow-y: scroll;
+}
+
+.hasNavbar {
+  height: calc(100vh - #{$nav-height});
+}

--- a/src/components/common/_layout/Page/styles.module.scss
+++ b/src/components/common/_layout/Page/styles.module.scss
@@ -3,8 +3,11 @@
 .pageContainer {
   width: 100%;
   height: 100vh;
-  padding: 0 15px;
   overflow-y: auto;
+
+  & > div {
+    height: 100%;
+  }
 }
 
 .hasNavbar {

--- a/src/components/common/_layout/Page/styles.module.scss
+++ b/src/components/common/_layout/Page/styles.module.scss
@@ -4,7 +4,7 @@
   width: 100%;
   height: 100vh;
   padding: 0 15px;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .hasNavbar {

--- a/src/components/common/_layout/ProtectedLayout/ProtectedLayout.tsx
+++ b/src/components/common/_layout/ProtectedLayout/ProtectedLayout.tsx
@@ -1,0 +1,7 @@
+import { Navigate, Outlet } from 'react-router-dom'
+import { useAuthStore } from '@/stores/authStore'
+
+export const ProtectedLayout: React.FC = () => {
+  const isLoggedIn = useAuthStore(state => state.isLoggedIn)()
+  return isLoggedIn ? <Outlet /> : <Navigate to="/login" replace />
+}

--- a/src/components/common/index.ts
+++ b/src/components/common/index.ts
@@ -1,4 +1,6 @@
 export { RootLayout } from './_layout/RootLayout/RootLayout'
+export { ProtectedLayout } from './_layout/ProtectedLayout/ProtectedLayout'
+export { Page } from './_layout/Page/Page'
 
 export { LoadingIndicator } from './_ui/LoadingIndicator/LoadingIndicator'
 export { Dropdown } from './_ui/Dropdown/Dropdown'
@@ -6,3 +8,4 @@ export { StaticTag } from './_ui/StaticTag/StaticTag'
 export { ClickableTag } from './_ui/ClickableTag/ClickableTag'
 
 export { SeatMap } from './SeatMap/SeatMap'
+export { Navbar } from './Navbar/Navbar'

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,3 +1,0 @@
-export const HomePage: React.FC = () => {
-  return <div className="HomePage">홈 페이지</div>
-}

--- a/src/pages/auth/LoginPage/LoginPage.tsx
+++ b/src/pages/auth/LoginPage/LoginPage.tsx
@@ -4,7 +4,7 @@ import introImage from '@assets/intro-image.png'
 
 export const LoginPage: React.FC = () => {
   return (
-    <div className={styles.pageContainer}>
+    <div className={styles.loginPage}>
       <div className={styles.introContent}>
         <img src={introImage} alt="img" />
         <p className={styles.greeting}>

--- a/src/pages/auth/LoginPage/styles.module.scss
+++ b/src/pages/auth/LoginPage/styles.module.scss
@@ -1,4 +1,4 @@
-.pageContainer {
+.loginPage {
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/auth/LoginRedirectPage/LoginRedirectPage.tsx
+++ b/src/pages/auth/LoginRedirectPage/LoginRedirectPage.tsx
@@ -51,7 +51,7 @@ export const LoginRedirectPage: React.FC = () => {
   }, [navigate, location.search, setTokens, setIsNewUser])
 
   return (
-    <div className={styles.pageContainer}>
+    <div className={styles.loginRedirectPage}>
       <LoadingIndicator />
       <p>로그인 중...</p>
     </div>

--- a/src/pages/auth/LoginRedirectPage/styles.module.scss
+++ b/src/pages/auth/LoginRedirectPage/styles.module.scss
@@ -1,4 +1,4 @@
-.pageContainer {
+.loginRedirectPage {
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/auth/ProfileSetupPage/ProfileSetupPage.tsx
+++ b/src/pages/auth/ProfileSetupPage/ProfileSetupPage.tsx
@@ -18,7 +18,7 @@ export const ProfileSetupPage: React.FC = () => {
   }, [])
 
   return (
-    <div className={styles.pageContainer}>
+    <div className={styles.profileSetupPage}>
       <h2 className={styles.guideText}>
         매칭에 필요한 <br />
         정보를 입력해주세요.

--- a/src/pages/auth/ProfileSetupPage/styles.module.scss
+++ b/src/pages/auth/ProfileSetupPage/styles.module.scss
@@ -1,6 +1,6 @@
 @import '@/styles/variables';
 
-.pageContainer {
+.profileSetupPage {
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/pages/common/ComingSoonPage/ComingSoonPage.tsx
+++ b/src/pages/common/ComingSoonPage/ComingSoonPage.tsx
@@ -1,0 +1,21 @@
+import { useNavigate } from 'react-router-dom'
+import wing from '@assets/wing.png'
+import styles from './styles.module.scss'
+
+export const ComingSoonPage: React.FC = () => {
+  const navigate = useNavigate()
+
+  return (
+    <div className={styles.comingSoonPage}>
+      <div className={styles.noticeBox}>
+        <img src={wing} alt="" />
+        <h1>
+          페이지 <span>준비중</span>입니다.
+        </h1>
+        <button className={styles.homeButton} onClick={() => navigate('/')}>
+          홈으로 이동
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/common/ComingSoonPage/styles.module.scss
+++ b/src/pages/common/ComingSoonPage/styles.module.scss
@@ -1,0 +1,44 @@
+@import '@/styles/variables';
+
+.comingSoonPage {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: $secondary;
+}
+
+.noticeBox {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  background-color: #fff;
+  border-radius: 20px;
+  padding: 35px 0;
+  width: 80%;
+
+  img {
+    width: 100px;
+    margin-bottom: 10px;
+  }
+
+  h1 {
+    font-size: 20px;
+    font-weight: 700;
+    margin-bottom: 10px;
+    color: #333;
+
+    span {
+      font-weight: 900;
+      color: $primary;
+    }
+  }
+}
+
+.homeButton {
+  font-size: 15px;
+  padding: 10px 20px;
+  background-color: $primary;
+  color: #fff;
+  border-radius: 7px;
+}

--- a/src/pages/home/HomePage/HomePage.tsx
+++ b/src/pages/home/HomePage/HomePage.tsx
@@ -1,0 +1,5 @@
+import styles from './styles.module.scss'
+
+export const HomePage: React.FC = () => {
+  return <div className={styles.homePage}>홈 페이지</div>
+}

--- a/src/pages/home/HomePage/styles.module.scss
+++ b/src/pages/home/HomePage/styles.module.scss
@@ -1,0 +1,4 @@
+@import '@/styles/variables';
+
+.homePage {
+}

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,4 +1,4 @@
-export { HomePage } from './HomePage/HomePage'
+export { HomePage } from './home/HomePage/HomePage'
 
 export { LoginPage } from './auth/LoginPage/LoginPage'
 export { LoginRedirectPage } from './auth/LoginRedirectPage/LoginRedirectPage'

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -3,3 +3,5 @@ export { HomePage } from './home/HomePage/HomePage'
 export { LoginPage } from './auth/LoginPage/LoginPage'
 export { LoginRedirectPage } from './auth/LoginRedirectPage/LoginRedirectPage'
 export { ProfileSetupPage } from './auth/ProfileSetupPage/ProfileSetupPage'
+
+export { ComingSoonPage } from './common/ComingSoonPage/ComingSoonPage'

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -15,7 +15,10 @@ const routes: RouteObject[] = [
         children: [
           {
             element: <Page hasNavbar={true} />,
-            children: [{ index: true, element: <P.HomePage /> }],
+            children: [
+              { index: true, element: <P.HomePage /> },
+              { path: 'coming-soon', element: <P.ComingSoonPage /> },
+            ],
           },
 
           {

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,12 +1,6 @@
-import { RouteObject, Navigate, Outlet } from 'react-router-dom'
-import { useAuthStore } from '@/stores/authStore'
-import { RootLayout } from '@/components/common'
+import { RouteObject } from 'react-router-dom'
+import { RootLayout, ProtectedLayout, Page } from '@/components/common'
 import * as P from '@/pages'
-
-const ProtectedRoute: React.FC = () => {
-  const isLoggedIn = useAuthStore(state => state.isLoggedIn)()
-  return isLoggedIn ? <Outlet /> : <Navigate to="/login" replace />
-}
 
 const routes: RouteObject[] = [
   {
@@ -17,11 +11,19 @@ const routes: RouteObject[] = [
       { path: 'auth/kakao', element: <P.LoginRedirectPage /> },
 
       {
-        element: <ProtectedRoute />,
+        element: <ProtectedLayout />,
         children: [
-          { index: true, element: <P.HomePage /> },
-          { path: 'profile-setup', element: <P.ProfileSetupPage /> },
-          //..
+          {
+            element: <Page hasNavbar={true} />,
+            children: [{ index: true, element: <P.HomePage /> }],
+          },
+
+          {
+            element: <Page hasNavbar={false} />,
+            children: [
+              { path: 'profile-setup', element: <P.ProfileSetupPage /> },
+            ],
+          },
         ],
       },
     ],

--- a/src/styles/_variables.scss
+++ b/src/styles/_variables.scss
@@ -1,2 +1,4 @@
 $primary: #3b80b7;
 $secondary: #6dadd1;
+
+$nav-height: 60px;


### PR DESCRIPTION
## Description

로그인 후 홈으로 이동했을 때 페이지 하단에 나타나는 네비게이션 `Navbar` 컴포넌트와 `Navbar` 가 렌더링되는 페이지와 없는 페이지를 구분하는 `Page` 레이아웃을 작성했습니다. 또한 메뉴 버튼을 눌렀을때 빈 페이지는 준비중 페이지를 보여주도록 UI를 추가했습니다.

## Related Issues

- close #17 

## Changes Made

1. 기존 라우터에 `Page` 레이아웃을 추가하고 `hasNavbar` props를 전달해서 `Navbar` 렌더링 여부 결정
```tsx
{
  element: <ProtectedLayout />,
  children: [
    {
      element: <Page hasNavbar={true} />, // 메뉴바 있는 페이지
      children: [
        { index: true, element: <P.HomePage /> },
        { path: 'coming-soon', element: <P.ComingSoonPage /> },
      ],
    },

    {
      element: <Page hasNavbar={false} />, // 메뉴바 없는 페이지
      children: [
        { path: 'profile-setup', element: <P.ProfileSetupPage /> },
      ],
    },
  ],
},
```

## Screenshots 

<img width="288" alt="Screenshot 2025-05-04 at 2 10 06 PM" src="https://github.com/user-attachments/assets/67645377-71b3-48be-8852-1c41764efc94" />

### Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [ ] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [ ] 모든 테스트가 성공적으로 통과했습니다.
- [ ] 관련 문서를 업데이트했습니다.
- [ ] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [ ] 코드 스타일 가이드라인을 준수했습니다.
- [ ] 코드 리뷰어를 지정했습니다.

### Additional Notes

<!--
  리뷰어가 이해하는 데 도움이 될 추가적인 참고 사항이나 정보가 있다면 여기에 작성하세요.
-->
