### PR TITLE
[feat] 1:1 모의면접 매칭 결과 페이지 UI 및 매칭 결과 프로필 API 추가

### DIFF
--- a/src/api/matchAPI.ts
+++ b/src/api/matchAPI.ts
@@ -28,7 +28,7 @@ export const fetchApplicantCount = async () => {
 export const fetchMatchingResult = async () => {
   try {
     const response =
-      await apiClient.get<ApiResponse<UserData>>('/matching/result')
+      await apiClient.get<ApiResponse<MatchResultData>>('/matching/result')
     console.log('🎉 매칭 결과 조회 성공:', response.data)
     return response.data
   } catch (error) {

--- a/src/components/match/MatchInfoCard/MatchInfoCard.tsx
+++ b/src/components/match/MatchInfoCard/MatchInfoCard.tsx
@@ -1,0 +1,62 @@
+import defaultImage from '@assets/default-profile.png'
+import styles from './styles.module.scss'
+import { StaticTag } from '@/components/common'
+
+interface MatchInfoCardProps {
+  interviewer: BaseProfile
+  interviewee: BaseProfile
+}
+
+export const MatchInfoCard: React.FC<MatchInfoCardProps> = ({
+  interviewer,
+  interviewee,
+}: MatchInfoCardProps) => {
+  console.log(interviewer, interviewee)
+
+  return (
+    <div className={styles.matchInfoCard}>
+      <div className={`${styles.container} ${styles.interviewerCard}`}>
+        <img src={defaultImage} alt="profile" className={styles.profileImage} />
+        <div className={styles.profileData}>
+          <h3 className={styles.name}>
+            {`${interviewer.nickname} (${interviewer.name}) / ${interviewer.curriculum}`}
+          </h3>
+          <div className={styles.myStacks}>
+            <StaticTag label="희망직무" />
+            <p>{interviewer.jobInterest.join(' | ')}</p>
+          </div>
+          <div className={styles.myStacks}>
+            <StaticTag label="기술스택" dark />
+            <p>{interviewer.techStack.join(' | ')}</p>
+          </div>
+        </div>
+      </div>
+
+      <div className={styles.roleName}>
+        <div className={styles.interviewer}>
+          <p>INTERVIEWER</p>
+        </div>
+        <div className={styles.interviewee}>
+          <p>INTERVIEWEE</p>
+        </div>
+      </div>
+
+      <div className={`${styles.container} ${styles.intervieweeCard}`}>
+        <div className={styles.profileData}>
+          <h3 className={styles.name}>
+            {`${interviewee.nickname} (${interviewee.name}) / ${interviewee.curriculum}`}
+          </h3>
+          <div className={styles.myStacks}>
+            <p>{interviewee.jobInterest.join(' | ')}</p>
+            <StaticTag label="희망직무" />
+          </div>
+          <div className={styles.myStacks}>
+            <p>{interviewee.techStack.join(' | ')}</p>
+            <StaticTag label="기술스택" dark />
+          </div>
+        </div>
+        <img src={defaultImage} alt="profile" className={styles.profileImage} />
+      </div>
+    </div>
+  )
+}

--- a/src/components/match/MatchInfoCard/MatchInfoCard.tsx
+++ b/src/components/match/MatchInfoCard/MatchInfoCard.tsx
@@ -1,22 +1,31 @@
 import defaultImage from '@assets/default-profile.png'
 import styles from './styles.module.scss'
 import { StaticTag } from '@/components/common'
+import { MapPin } from 'lucide-react'
 
 interface MatchInfoCardProps {
-  interviewer: BaseProfile
-  interviewee: BaseProfile
+  interviewer: UserData
+  interviewee: UserData
 }
 
 export const MatchInfoCard: React.FC<MatchInfoCardProps> = ({
   interviewer,
   interviewee,
 }: MatchInfoCardProps) => {
-  console.log(interviewer, interviewee)
-
   return (
     <div className={styles.matchInfoCard}>
       <div className={`${styles.container} ${styles.interviewerCard}`}>
-        <img src={defaultImage} alt="profile" className={styles.profileImage} />
+        <div className={styles.imageWrapper}>
+          <img
+            src={defaultImage}
+            alt="profile"
+            className={styles.profileImage}
+          />
+          <span className={styles.seatCode}>
+            <MapPin />
+            {interviewer.seatCode}
+          </span>
+        </div>
         <div className={styles.profileData}>
           <h3 className={styles.name}>
             {`${interviewer.nickname} (${interviewer.name}) / ${interviewer.curriculum}`}

--- a/src/components/match/MatchInfoCard/styles.module.scss
+++ b/src/components/match/MatchInfoCard/styles.module.scss
@@ -1,0 +1,102 @@
+@import '@/styles/variables';
+
+.matchInfoCard {
+  width: 90%;
+  border-radius: 20px;
+  margin-top: -80px;
+  background: #fff;
+  border: 10px solid $primary;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.container {
+  display: flex;
+  padding: 20px 15px;
+}
+
+.profileImage {
+  width: 70px;
+  height: 70px;
+  border-radius: 50%;
+  border: 1px solid #e1e1e1;
+}
+
+.profileData {
+  flex: 1;
+
+  .name {
+    font-weight: 600;
+    font-size: 15px;
+    margin: 0 6px 6px;
+  }
+}
+
+.myStacks {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+
+  & + & {
+    margin-top: 5px;
+  }
+
+  div {
+    margin: 0 5px;
+    height: 20px;
+    line-height: 1;
+  }
+
+  p {
+    flex: 1;
+    font-size: 13px;
+    word-break: keep-all;
+  }
+}
+
+.interviewerCard {
+  .profileImage {
+    margin-right: 10px;
+    margin-top: 10px;
+  }
+}
+
+.intervieweeCard {
+  background-color: $primary;
+  text-align: right;
+  color: #fff;
+
+  .profileImage {
+    margin-left: 10px;
+  }
+}
+
+.roleName {
+  display: flex;
+  justify-content: space-between;
+
+  div {
+    flex: 1;
+    text-align: center;
+    letter-spacing: 1px;
+    font-size: 15px;
+  }
+
+  p {
+    padding: 10px 0;
+  }
+
+  .interviewer {
+    background-color: $primary;
+    p {
+      border-bottom-right-radius: 25px;
+      background-color: #fff;
+    }
+  }
+
+  .interviewee {
+    border-top-left-radius: 25px;
+    background-color: $primary;
+    color: #fff;
+    position: relative;
+  }
+}

--- a/src/components/match/MatchInfoCard/styles.module.scss
+++ b/src/components/match/MatchInfoCard/styles.module.scss
@@ -56,7 +56,21 @@
 .interviewerCard {
   .profileImage {
     margin-right: 10px;
-    margin-top: 10px;
+    margin-top: 5px;
+  }
+
+  .seatCode {
+    display: flex;
+    align-items: center;
+    margin-left: 11px;
+    margin-top: 3px;
+    font-size: 12px;
+    color: #888;
+
+    svg {
+      width: 12px;
+      height: 12px;
+    }
   }
 }
 

--- a/src/components/match/index.ts
+++ b/src/components/match/index.ts
@@ -1,0 +1,1 @@
+export { MatchInfoCard } from './MatchInfoCard/MatchInfoCard'

--- a/src/pages/home/HomePage/HomePage.tsx
+++ b/src/pages/home/HomePage/HomePage.tsx
@@ -7,7 +7,9 @@ import {
   Logo,
   ProfileCard,
 } from '@/components/common'
-import { useApplicantCount, useMatchResult, useMatchStart } from '@/hooks/match'
+import { useApplicantCount, useMatchStart } from '@/hooks/match'
+import { useMatchStore } from '@/stores/matchStore'
+import { fetchMatchingResult } from '@/api/matchAPI'
 
 export const HomePage: React.FC = () => {
   const { data: applicantCount } = useApplicantCount()
@@ -15,28 +17,38 @@ export const HomePage: React.FC = () => {
 
   const [isMatching, setIsMatching] = useState<boolean>(false)
 
-  const { data: matchResult } = useMatchResult(isMatching)
-  const isMatched = !!matchResult?.data
+  // const { data: matchResult } = useMatchResult(isMatching)
+
+  const { matchResult, setMatchResult } = useMatchStore()
 
   const navigate = useNavigate()
 
-  const handleMatchStart = () => {
+  const handleMatchStart = async () => {
     if (isPending) {
       console.log('이미 매칭이 진행 중 입니다.')
       return // 중복 요청 방지
     }
 
-    setTimeout(() => {
-      navigate('/match/result')
-    }, 3000)
-
     mutateMatchStart()
     setIsMatching(true)
+
+    const { data: matched } = await fetchMatchingResult()
+
+    if (matched) {
+      setMatchResult(matched)
+      navigate('/match/result')
+    }
+
+    // setTimeout(() => {
+    //   navigate('/match/result')
+    // }, 3000)
   }
 
   useEffect(() => {
-    if (isMatched) navigate('/match/result') // 매칭 완료 시 결과 페이지로 이동
-  }, [isMatched, navigate])
+    if (matchResult) {
+      navigate('/match/result')
+    }
+  }, [navigate, matchResult])
 
   return (
     <div className={styles.homePage}>

--- a/src/pages/home/HomePage/HomePage.tsx
+++ b/src/pages/home/HomePage/HomePage.tsx
@@ -25,14 +25,17 @@ export const HomePage: React.FC = () => {
       console.log('이미 매칭이 진행 중 입니다.')
       return // 중복 요청 방지
     }
+
+    setTimeout(() => {
+      navigate('/match/result')
+    }, 3000)
+
     mutateMatchStart()
     setIsMatching(true)
   }
 
   useEffect(() => {
-    if (isMatched) {
-      navigate('/match/result') // 매칭 완료 시 결과 페이지로 이동
-    }
+    if (isMatched) navigate('/match/result') // 매칭 완료 시 결과 페이지로 이동
   }, [isMatched, navigate])
 
   return (

--- a/src/pages/match/MatchResultPage/MatchResultPage.tsx
+++ b/src/pages/match/MatchResultPage/MatchResultPage.tsx
@@ -1,5 +1,6 @@
 import { MatchInfoCard } from '@/components/match'
 import { Button, Logo } from '@/components/common'
+import { useMatchStore } from '@/stores/matchStore'
 import styles from './styles.module.scss'
 
 const dummyData = {
@@ -9,17 +10,15 @@ const dummyData = {
     nickname: 'leo.kim',
     name: '김광현',
     curriculum: '풀스택',
-    profileImage: '<Multipart File>',
     jobInterest: ['프론트엔드 개발자', '백엔드 개발자'],
     techStack: ['Java', 'Javascript'],
-    seatCode: 'a_3_m',
+    seatCode: 'A-3-M',
     seatPosition: { section: 'A', seat: [3, 1] },
   },
   interviewee: {
     nickname: 'joy.lee',
     name: '이주영',
     curriculum: '클라우드',
-    profileImage: '<Multipart File>',
     jobInterest: ['DevOps 엔지니어'],
     techStack: ['python'],
   },
@@ -27,7 +26,14 @@ const dummyData = {
 }
 
 export const MatchResultPage: React.FC = () => {
-  const iamInterviewer = false
+  const me = JSON.parse(localStorage.getItem('myProfile') as string).nickname
+  const myNickname = me.split('.')[0]
+
+  const { matchResult } = useMatchStore()
+
+  const data = matchResult || dummyData
+
+  const iamInterviewer = me.nickname === data.interviewer.nickname
 
   return (
     <div className={styles.matchResultPage}>
@@ -42,27 +48,27 @@ export const MatchResultPage: React.FC = () => {
 
       <div className={styles.pageContent}>
         <MatchInfoCard
-          interviewer={dummyData.interviewer}
-          interviewee={dummyData.interviewee}
+          interviewer={data.interviewer}
+          interviewee={data.interviewee}
         />
 
         <div className={styles.myCurrentRole}>
           {iamInterviewer ? (
             <p className={styles.message}>
-              joy 님은 <span>1ROUND 면접관</span>입니다.
+              {myNickname}님은 <span>1ROUND 면접관</span>입니다.
               <br />
               잠시 후 면접 대기 화면으로 이동합니다.
             </p>
           ) : (
             <>
               <p className={styles.message}>
-                joy 님은 <span>1ROUND 면접자</span>입니다.
+                {myNickname}님은 <span>1ROUND 면접자</span>입니다.
                 <br />
                 면접관의 자리로 이동해주세요.
               </p>
               <Button
                 text="면접관 자리 보기"
-                onClick={() => console.log('hi')}
+                onClick={() => console.log('면접관 자리 보기 클릭')}
               />
             </>
           )}

--- a/src/pages/match/MatchResultPage/MatchResultPage.tsx
+++ b/src/pages/match/MatchResultPage/MatchResultPage.tsx
@@ -1,5 +1,73 @@
+import { MatchInfoCard } from '@/components/match'
+import { Button, Logo } from '@/components/common'
 import styles from './styles.module.scss'
 
+const dummyData = {
+  isFirstInterviewer: false,
+  isAiInterview: false,
+  interviewer: {
+    nickname: 'leo.kim',
+    name: '김광현',
+    curriculum: '풀스택',
+    profileImage: '<Multipart File>',
+    jobInterest: ['프론트엔드 개발자', '백엔드 개발자'],
+    techStack: ['Java', 'Javascript'],
+    seatCode: 'a_3_m',
+    seatPosition: { section: 'A', seat: [3, 1] },
+  },
+  interviewee: {
+    nickname: 'joy.lee',
+    name: '이주영',
+    curriculum: '클라우드',
+    profileImage: '<Multipart File>',
+    jobInterest: ['DevOps 엔지니어'],
+    techStack: ['python'],
+  },
+  interviewId: 'de305d54-75b4-431b-adb2-eb6b9e546014',
+}
+
 export const MatchResultPage: React.FC = () => {
-  return <div className={styles.matchResultPage}>매칭 결과 페이지</div>
+  const iamInterviewer = false
+
+  return (
+    <div className={styles.matchResultPage}>
+      <div className={styles.pageHeader}>
+        <Logo width={60} color="light" />
+        <h1>
+          1:1 모의면접 매칭이
+          <br />
+          완료되었습니다!
+        </h1>
+      </div>
+
+      <div className={styles.pageContent}>
+        <MatchInfoCard
+          interviewer={dummyData.interviewer}
+          interviewee={dummyData.interviewee}
+        />
+
+        <div className={styles.myCurrentRole}>
+          {iamInterviewer ? (
+            <p className={styles.message}>
+              joy 님은 <span>1ROUND 면접관</span>입니다.
+              <br />
+              잠시 후 면접 대기 화면으로 이동합니다.
+            </p>
+          ) : (
+            <>
+              <p className={styles.message}>
+                joy 님은 <span>1ROUND 면접자</span>입니다.
+                <br />
+                면접관의 자리로 이동해주세요.
+              </p>
+              <Button
+                text="면접관 자리 보기"
+                onClick={() => console.log('hi')}
+              />
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  )
 }

--- a/src/pages/match/MatchResultPage/styles.module.scss
+++ b/src/pages/match/MatchResultPage/styles.module.scss
@@ -3,3 +3,43 @@
 .matchResultPage {
   height: 100%;
 }
+
+.pageHeader {
+  background-color: $secondary;
+  padding: 70px 20px 0;
+  height: 300px;
+
+  h1 {
+    font-size: 25px;
+    font-weight: 600;
+    letter-spacing: -1px;
+    line-height: 1.3;
+    margin-top: 30px;
+    color: #fff;
+  }
+}
+
+.pageContent {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+}
+
+.myCurrentRole {
+  margin-top: 50px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+
+  .message {
+    font-size: 17px;
+    text-align: center;
+    margin-bottom: 20px;
+  }
+
+  .message span {
+    font-size: 18px;
+    font-weight: 700;
+  }
+}

--- a/src/pages/match/MatchResultPage/styles.module.scss
+++ b/src/pages/match/MatchResultPage/styles.module.scss
@@ -27,7 +27,7 @@
 }
 
 .myCurrentRole {
-  margin-top: 50px;
+  margin-top: 60px;
   display: flex;
   flex-direction: column;
   align-items: center;

--- a/src/stores/matchStore.ts
+++ b/src/stores/matchStore.ts
@@ -1,0 +1,11 @@
+import { create } from 'zustand'
+
+interface MatchResultState {
+  matchResult: MatchResultData | null
+  setMatchResult: (result: MatchResultData) => void
+}
+
+export const useMatchStore = create<MatchResultState>(set => ({
+  matchResult: null,
+  setMatchResult: result => set({ matchResult: result }),
+}))

--- a/src/types/match.d.ts
+++ b/src/types/match.d.ts
@@ -1,0 +1,7 @@
+interface MatchResultData {
+  isFirstInterviewer: boolean
+  isAiInterview: boolean
+  interviewer: UserData
+  interviewee: UserData
+  interviewId: string
+}


### PR DESCRIPTION
## Description

1:1 모의면접 매칭이 완료된 후 매칭 상대 프로필을 확인할 수 있는 페이지입니다. `fetchMatchingResult` 로 서버로 매칭결과를 요청하면 면접관과 면접자의 역할이 부여된 프로필 데이터를 응답받습니다. 본인의 역할을 명확히 파악할 수 있도록 UI를 만들고 역할에 따라 다음 액션을 알려주는 텍스트도 추가했습니다.

## Related Issues

- close #32 
- close #33 
- close #34 

## Changes Made

1. 매칭 대기페이지에 매칭 완료 시 결과페이지로 이동하도록 구현
```tsx
useEffect(() => {
  if (matchResult) {
    navigate('/match/result')
  }
}, [navigate, matchResult])
```

2. 매칭 결과가 생성되면 store에 상태 저장
```tsx
export const useMatchStore = create<MatchResultState>(set => ({
  matchResult: null,
  setMatchResult: result => set({ matchResult: result }),
}))
```

## Screenshots or Video

<img width="280" alt="Screenshot 2025-05-08 at 9 08 47 AM" src="https://github.com/user-attachments/assets/96d7dfec-6835-4b64-b940-44fdbd999b83" />


## Checklist

<!--
  PR 작성 시 다음 항목들을 확인하세요.
-->

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.
