### PR TITLE
[bugfix] 매칭 결과 요청 및 인터뷰 분기 처리 관련 예외처리

### DIFF
--- a/src/api/matchAPI.ts
+++ b/src/api/matchAPI.ts
@@ -36,16 +36,7 @@ export const fetchMatchingResult = async () => {
   } catch (error) {
     if (axios.isAxiosError(error)) {
       if (error.response) {
-        if (error.response.data.message === 'INVALID_USER') {
-          return {
-            success: true,
-            message: '매칭 큐에 진입하지 않은 사용자',
-            data: null,
-          }
-        } else {
-          console.error('매칭 결과 조회 실패:', error)
-          throw error
-        }
+        if (error.response.data.message !== 'INVALID_USER') throw error
       }
     }
   }

--- a/src/api/profileAPI.ts
+++ b/src/api/profileAPI.ts
@@ -17,7 +17,7 @@ export const submitUserProfile = async (profileData: ProfileFormData) => {
 
 export const fetchMyProfile = async () => {
   try {
-    const response = await apiClient.get<ApiResponse<UserData>>(
+    const response = await apiClient.get<ApiResponse<MyProfileData>>(
       API.PROFILE.MY_PROFILE
     )
     console.log('🎉 사용자 정보 조회 성공:', response.data.data)

--- a/src/components/common/ProfileCard/ProfileCard.tsx
+++ b/src/components/common/ProfileCard/ProfileCard.tsx
@@ -3,7 +3,7 @@ import defaultImage from '@assets/default-profile.png'
 import styles from './styles.module.scss'
 
 interface ProfileCardProps {
-  profile: UserData
+  profile: MyProfileData
 }
 
 export const ProfileCard: React.FC<ProfileCardProps> = ({ profile }) => {

--- a/src/components/common/_layout/InterviewLayout/InterviewLayout.tsx
+++ b/src/components/common/_layout/InterviewLayout/InterviewLayout.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { Outlet, useNavigate } from 'react-router-dom'
-import { Logo } from '@/components/common'
+import { Button, Logo, Modal } from '@/components/common'
 import { Timer } from '@/components/interview'
 import { useInterviewStore } from '@/stores/interviewStore'
 import { getInterviewRouteByPhase } from '@/utils'
@@ -10,6 +10,8 @@ export const InterviewLayout: React.FC = () => {
   const { isInterviewer, currentPhase, questionOption, selectedQuestion } =
     useInterviewStore()
   const navigate = useNavigate()
+
+  const isLastRoundDone = currentPhase.toUpperCase() === 'COMPLETE'
 
   useEffect(() => {
     if (!isInterviewer) {
@@ -38,6 +40,15 @@ export const InterviewLayout: React.FC = () => {
       <div className={styles.pageContent}>
         <Outlet />
       </div>
+
+      <Modal
+        isOpen={isLastRoundDone}
+        closeOnBgClick={false}
+        style="congrats"
+        message={['오늘의 면접이 모두 종료되었습니다', '수고하셨습니다.']}
+      >
+        <Button text="홈으로 이동" onClick={() => navigate('/')} />
+      </Modal>
     </div>
   )
 }

--- a/src/components/match/MatchInfoCard/MatchInfoCard.tsx
+++ b/src/components/match/MatchInfoCard/MatchInfoCard.tsx
@@ -4,8 +4,8 @@ import { StaticTag } from '@/components/common'
 import { MapPin } from 'lucide-react'
 
 interface MatchInfoCardProps {
-  interviewer: UserData
-  interviewee: UserData
+  interviewer: InterviewerData
+  interviewee: IntervieweeData
 }
 
 export const MatchInfoCard: React.FC<MatchInfoCardProps> = ({

--- a/src/hooks/interview.ts
+++ b/src/hooks/interview.ts
@@ -18,6 +18,7 @@ export const useUpdateInterviewStatus = (options?: {
 }
 
 export const useGenerateQuestion = (options?: {
+  onMutate?: () => void
   onSuccess?: (data: ApiResponse<QuestionListData>) => void
   onError?: (error: unknown) => void
 }) => {
@@ -30,6 +31,7 @@ export const useGenerateQuestion = (options?: {
         params.interviewId,
         params.questionData || { question: '', keywords: '' }
       ),
+    onMutate: options?.onMutate,
     onSuccess: options?.onSuccess,
     onError: options?.onError,
   })

--- a/src/hooks/match.ts
+++ b/src/hooks/match.ts
@@ -31,11 +31,19 @@ export const useApplicantCount = () => {
   })
 }
 
-export const useMatchResult = (isPolling: boolean) => {
+export const useMatchResult = (
+  options: {
+    enablePolling?: boolean
+    isInQueue?: boolean
+  } = {}
+) => {
+  const { enablePolling = false, isInQueue = false } = options
+
   return useQuery({
     queryKey: ['matchingResult'],
     queryFn: fetchMatchingResult,
-    refetchInterval: isPolling ? 3000 : false,
+    refetchInterval: enablePolling ? 3000 : false,
+    enabled: !!isInQueue,
     staleTime: 0,
   })
 }

--- a/src/hooks/profile.ts
+++ b/src/hooks/profile.ts
@@ -2,7 +2,7 @@ import { submitUserProfile, fetchMyProfile } from '@/api/profileAPI'
 import { useMutation, useQuery } from '@tanstack/react-query'
 
 export const useMyProfile = () => {
-  return useQuery<UserData>({
+  return useQuery<MyProfileData>({
     queryKey: ['myProfile'],
     queryFn: fetchMyProfile,
   })

--- a/src/pages/home/HomePage/HomePage.tsx
+++ b/src/pages/home/HomePage/HomePage.tsx
@@ -15,7 +15,10 @@ export const HomePage: React.FC = () => {
 
   const { data: myData } = useMyProfile()
   const { data: applicantCount } = useApplicantCount()
-  const { data: matchResult } = useMatchResult(isMatching)
+  const { data: matchResult } = useMatchResult({
+    enablePolling: isMatching,
+    isInQueue: myData && myData.isInQueue,
+  })
   const { mutate: startMatching, isPending: isButtonClicked } = useMatchStart()
 
   const handleMatchStart = useCallback(() => {
@@ -49,7 +52,7 @@ export const HomePage: React.FC = () => {
   }, [location.state, myData])
 
   useEffect(() => {
-    if (matchResult) {
+    if (myData && myData.isInQueue && matchResult) {
       if (matchResult.data === null) {
         // 매칭 중
         setIsMatching(true)
@@ -57,10 +60,12 @@ export const HomePage: React.FC = () => {
         // 이미 매칭되서 결과가 있으면
         setMatchResultInStore(matchResult.data)
         setIsMatching(false)
-        navigate('/match/result', { state: { matchResult: matchResult.data } }) // 결과 페이지로 .
+        navigate('/match/result', {
+          state: { matchResult: matchResult.data },
+        })
       }
     }
-  }, [matchResult, navigate, setMatchResultInStore, setIsMatching])
+  }, [myData, matchResult, navigate, setMatchResultInStore, setIsMatching])
 
   return (
     <div className={styles.homePage}>

--- a/src/pages/home/HomePage/HomePage.tsx
+++ b/src/pages/home/HomePage/HomePage.tsx
@@ -10,7 +10,7 @@ export const HomePage: React.FC = () => {
   const location = useLocation()
   const navigate = useNavigate()
 
-  const [profile, setMyProfile] = useState<UserData>()
+  const [profile, setMyProfile] = useState<MyProfileData>()
   const { isMatching, setIsMatching, setMatchResultInStore } = useMatchStore()
 
   const { data: myData } = useMyProfile()

--- a/src/pages/interview/InterviewAwaitingPage/InterviewAwaitingPage.tsx
+++ b/src/pages/interview/InterviewAwaitingPage/InterviewAwaitingPage.tsx
@@ -47,15 +47,8 @@ export const InterviewAwaitingPage: React.FC = () => {
 
   const { startTimer, resetTimer } = useTimerStore()
   const { getOddInterviewee, getEvenInterviewee } = useMatchStore()
-  const {
-    interviewId,
-    isInterviewer,
-    currentRound,
-    currentPhase,
-    setInterviewData,
-  } = useInterviewStore()
-
-  const isLastRoundDone = currentPhase.toUpperCase() === 'COMPLETE'
+  const { interviewId, isInterviewer, currentRound, setInterviewData } =
+    useInterviewStore()
 
   const { data: matchResult } = useMatchResult(false)
   const { data: currentStatus, refetch } = useInterviewStatus(interviewId)
@@ -251,15 +244,6 @@ export const InterviewAwaitingPage: React.FC = () => {
           '면접 상대가 정해지지 않았습니다.',
           '1:1 매칭을 먼저 진행해주세요.',
         ]}
-      >
-        <Button text="홈으로 이동" onClick={() => navigate('/')} />
-      </Modal>
-
-      <Modal
-        isOpen={isLastRoundDone}
-        closeOnBgClick={false}
-        style="congrats"
-        message={['오늘의 면접이 모두 종료되었습니다', '수고하셨습니다.']}
       >
         <Button text="홈으로 이동" onClick={() => navigate('/')} />
       </Modal>

--- a/src/pages/interview/InterviewAwaitingPage/InterviewAwaitingPage.tsx
+++ b/src/pages/interview/InterviewAwaitingPage/InterviewAwaitingPage.tsx
@@ -50,7 +50,10 @@ export const InterviewAwaitingPage: React.FC = () => {
   const { interviewId, isInterviewer, currentRound, setInterviewData } =
     useInterviewStore()
 
-  const { data: matchResult } = useMatchResult(false)
+  const { data: matchResult } = useMatchResult({
+    enablePolling: false,
+    isInQueue: true,
+  })
   const { data: currentStatus, refetch } = useInterviewStatus(interviewId)
   const { mutate: updateStatus } = useUpdateInterviewStatus({
     onSuccess: () => {

--- a/src/pages/interview/InterviewFeedbackPage/InterviewFeedbackPage.tsx
+++ b/src/pages/interview/InterviewFeedbackPage/InterviewFeedbackPage.tsx
@@ -23,7 +23,7 @@ export const InterviewFeedbackPage: React.FC = () => {
   const [feedback, setFeedback] = useState('')
   const [interviewee, setInterviewee] = useState<BaseProfile>()
 
-  const { interviewId, currentRound } = useInterviewStore()
+  const { interviewId, currentRound, setInterviewData } = useInterviewStore()
   const { data: interviewData } = useInterviewStatus(interviewId)
   const { mutate: updateStatus, isSuccess } = useUpdateInterviewStatus()
 
@@ -38,7 +38,10 @@ export const InterviewFeedbackPage: React.FC = () => {
     updateStatus(interviewId) // FEEDBACK -> PENDING
   }
 
-  const goToNextRound = () => navigate('/interview/awaiting')
+  const handleNextRound = () => {
+    navigate(isLastRound ? '/' : '/interview/awaiting')
+    setInterviewData({ currentPhase: isLastRound ? 'COMPLETE' : 'PENDING' })
+  }
 
   useEffect(() => {
     if (interviewData && interviewData.data) {
@@ -126,13 +129,13 @@ export const InterviewFeedbackPage: React.FC = () => {
           style="congrats"
           message={['피드백이 제출되었습니다!', '수고하셨습니다.']}
         >
-          <Button text="홈으로 이동" onClick={() => navigate('/')} />
+          <Button text="홈으로 이동" onClick={handleNextRound} />
         </Modal>
       ) : (
         <Modal
           isOpen={isSuccess}
           closeOnBgClick={false}
-          onYesClick={goToNextRound}
+          onYesClick={handleNextRound}
           style="congrats"
           message={[
             '피드백이 제출되었습니다!',

--- a/src/pages/interview/InterviewQuestionPage/InterviewQuestionPage.tsx
+++ b/src/pages/interview/InterviewQuestionPage/InterviewQuestionPage.tsx
@@ -35,6 +35,7 @@ export const InterviewQuestionPage: React.FC = () => {
   const [questions, setQuestions] = useState<string[]>([])
   const [selectedIdx, setSelectedIdx] = useState<number | null>(null)
   const [isRefreshDisabled, setIsRefreshDisabled] = useState<boolean>(false)
+  const [isGenerating, setIsGenerating] = useState<boolean>(false)
 
   const {
     interviewId,
@@ -59,21 +60,28 @@ export const InterviewQuestionPage: React.FC = () => {
     },
   })
 
-  const { mutate: generateQuestions, isPending: isGenerating } =
-    useGenerateQuestion({
-      onSuccess: result => {
-        if (result.data && result.data.questions) {
-          setQuestions(result.data.questions)
-          setInterviewData({ questionOption: result.data.questions })
-          setSelectedIdx(null)
-        }
+  // 새로 고침 눌렀을 때
+  const { mutate: generateQuestions } = useGenerateQuestion({
+    onMutate: () => setIsGenerating(true),
 
-        // 5초 후 새로고침 버튼 활성화
-        setTimeout(() => {
-          setIsRefreshDisabled(false)
-        }, 5000)
-      },
-    })
+    onSuccess: async result => {
+      const delay = new Promise(resolve => setTimeout(resolve, 1500))
+
+      await delay // 로딩 모달 창을 위한 1.5초 지연
+
+      if (result.data && result.data.questions) {
+        setQuestions(result.data.questions)
+        setInterviewData({ questionOption: result.data.questions })
+        setSelectedIdx(null)
+        setIsGenerating(false)
+      }
+
+      // 5초 후 새로고침 버튼 활성화
+      setTimeout(() => {
+        setIsRefreshDisabled(false)
+      }, 5000)
+    },
+  })
 
   const handleSelect = (idx: number) => {
     setSelectedIdx(idx + 1)
@@ -107,8 +115,6 @@ export const InterviewQuestionPage: React.FC = () => {
     }
   }, [questionsInRoute, questionOption, interviewId])
 
-  const isLoading = isGenerating || isRefreshDisabled
-
   return (
     <div className={styles.container}>
       <div className={styles.notice}>
@@ -126,7 +132,7 @@ export const InterviewQuestionPage: React.FC = () => {
         <button
           className={styles.resetButton}
           onClick={handleRefresh}
-          disabled={isLoading}
+          disabled={isRefreshDisabled}
         >
           <RefreshCw />
         </button>

--- a/src/pages/match/MatchResultPage/MatchResultPage.tsx
+++ b/src/pages/match/MatchResultPage/MatchResultPage.tsx
@@ -16,8 +16,10 @@ export const MatchResultPage: React.FC = () => {
   const matchResultInRoute = location.state?.matchResult
   const { matchResultInStore, setMatchResultInStore } = useMatchStore()
 
-  // const requestFetch = !matchResultInRoute && !matchResultInStore
-  const { data: matchResultFromApi, isLoading } = useMatchResult(false)
+  const { data: matchResultFromApi } = useMatchResult({
+    enablePolling: false,
+    isInQueue: true,
+  })
 
   const myNickname = localStorage.getItem('nickname')
   const iamInterviewer = result?.isFirstInterviewer
@@ -65,7 +67,6 @@ export const MatchResultPage: React.FC = () => {
     matchResultInStore,
     setMatchResultInStore,
     matchResultFromApi,
-    isLoading,
   ])
 
   useEffect(() => {

--- a/src/stores/timerStore.ts
+++ b/src/stores/timerStore.ts
@@ -11,7 +11,7 @@ export const useTimerStore = create<TimerState>(set => ({
   isActive: false,
   time: { minutes: 20, seconds: 0 },
 
-  startTimer: () => set({ isActive: true }),
+  startTimer: () => set({ isActive: true, time: { minutes: 19, seconds: 59 } }),
   resetTimer: (init = { minutes: 20, seconds: 0 }) =>
     set({ isActive: false, time: init }),
 }))

--- a/src/types/match.d.ts
+++ b/src/types/match.d.ts
@@ -1,7 +1,7 @@
 interface MatchResultData {
   isFirstInterviewer: boolean
   isAiInterview: boolean
-  interviewer: UserData
-  interviewee: UserData
+  interviewer: InterviewerData
+  interviewee: IntervieweeData
   interviewId: string
 }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -7,15 +7,21 @@ interface BaseProfile {
   profileImageUrl?: string | null
 }
 
+interface MyProfileData extends BaseProfile {
+  email: string
+  seatCode: string | null
+  interviewCnt: number
+}
+
+interface InterviewerData extends BaseProfile {
+  seatCode: string
+}
+
+type IntervieweeData = BaseProfile
+
 interface ProfileFormData extends BaseProfile {
   seatPosition: {
     section: string | null
     seat: [number | null, number | null]
   }
-}
-
-interface UserData extends BaseProfile {
-  email?: string
-  seatCode?: string
-  interviewCnt?: number
 }

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -11,6 +11,7 @@ interface MyProfileData extends BaseProfile {
   email: string
   seatCode: string | null
   interviewCnt: number
+  isInQueue: boolean
 }
 
 interface InterviewerData extends BaseProfile {


### PR DESCRIPTION
## Description

- 홈 페이지 진입 후 매칭 결과 요청 시, 400 Bad Request 에 대한 예외처리를 추가했습니다. 
- 면접의 모든 라운드가 종료 되면 COMPLETE 상태가 되는데 이때 필요한 UI를 보여줄 수 있도록 수정했습니다.
- 면접 질문 생성을 하는 동안 사용자가 문제 생성 중임을 알 수 있도록 하는 모달창에 대한 최소 딜레이를 추가했습니다.

## Related Issues

- close #88 
- close #102 
- close #105 

## Changes Made

자세한 내용은 상단의 이슈 트러블 슈팅 로그 참고

## Screenshots or Video

-  매칭 결과 요청 시 400 Error
<img width="800" alt="Screenshot 2025-05-19 at 9 22 23 AM" src="https://github.com/user-attachments/assets/f29dbe68-7b61-4185-8f73-6b3dd2837355" />

## Checklist

- [x] 코드가 정상적으로 컴파일되는지 확인했습니다.
- [x] 모든 테스트가 성공적으로 통과했습니다.
- [x] 관련 문서를 업데이트했습니다.
- [x] PR이 관련 이슈를 정확히 참조하고 있습니다.
- [x] 코드 스타일 가이드라인을 준수했습니다.
- [x] 코드 리뷰어를 지정했습니다.
